### PR TITLE
Added extra setting to decide which caldav components are supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,15 +178,13 @@ The resources can be of two types: collection and non-collection. A collection r
 
 ### Configuration
 
-You can set the caldav types your storage engine supports like so:
+The current supported CalDAV components by this lib are `VCALENDAR` and `VEVENT`. If your server implementation supports more components, you can set this up like so:
 
 ```go
-caldav.SetupSupportedComponents([]string{lib.VCALENDAR, lib.VEVENT})
+caldav.SetupSupportedComponents([]string{'VCALENDAR', 'VEVENT', 'VTODO'})
 ```
 
-The default is `lib.VCALENDAR` and `lib.VEVENT`.
-
-`caldav-go` will report these supported types to the client.
+This data is used internally and returned in some client responses, e.g, in multistatus responses under the `<supported-calendar-component-set>` tag.
 
 ### Features
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,18 @@ The default storage used (if none is explicitly set) is the `data.FileStorage` w
 
 The resources can be of two types: collection and non-collection. A collection resource is basically a resource that has children resources, but does not have any data content. A non-collection resource is a resource that does not have children, but has data. In the case of a file storage, collections correspond to directories and non-collection to plain files. The data of a caldav resource is all the info that shows up in the calendar client, in the [iCalendar](https://en.wikipedia.org/wiki/ICalendar) format.
 
+### Configuration
+
+You can set the caldav types your storage engine supports like so:
+
+```go
+caldav.SetupSupportedComponents([]string{lib.VCALENDAR, lib.VEVENT})
+```
+
+The default is `lib.VCALENDAR` and `lib.VEVENT`.
+
+`caldav-go` will report these supported types to the client.
+
 ### Features
 
 Please check the **CHANGELOG** to see specific features that are currently implemented.

--- a/config.go
+++ b/config.go
@@ -17,3 +17,8 @@ func SetupStorage(stg data.Storage) {
 func SetupUser(username string) {
 	global.User = &data.CalUser{Name: username}
 }
+
+// SetupSupportedComponents sets all components which are supported by this storage implementation.
+func SetupSupportedComponents(components []string) {
+	global.SupportedComponents = components
+}

--- a/data/resource.go
+++ b/data/resource.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/laurent22/ical-go/ical"
+	"github.com/laurent22/ical-go"
 
 	"github.com/samedi/caldav-go/files"
 	"github.com/samedi/caldav-go/lib"

--- a/data/resource.go
+++ b/data/resource.go
@@ -2,13 +2,14 @@ package data
 
 import (
 	"fmt"
-	"github.com/laurent22/ical-go/ical"
 	"io/ioutil"
 	"log"
 	"os"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/laurent22/ical-go/ical"
 
 	"github.com/samedi/caldav-go/files"
 	"github.com/samedi/caldav-go/lib"

--- a/data/resource.go
+++ b/data/resource.go
@@ -42,11 +42,6 @@ type ResourceAdapter interface {
 	GetModTime() time.Time
 }
 
-// ResourceComponenter returns all supported components as strings, such as vtodo vevent etc
-type ResourceComponenter interface {
-	GetSupportedComponents() []string
-}
-
 // ResourceRecurrence represents a recurrence for a resource.
 // NOTE: recurrences are not supported yet.
 type ResourceRecurrence struct {
@@ -284,15 +279,6 @@ func (r *Resource) GetOwnerPath() (string, bool) {
 	}
 
 	return "", false
-}
-
-// GetSupportedComponents returns the components supported by a store
-func (r *Resource) GetSupportedComponents() []string {
-	// We're checking if the storage adapter implements the interface to not break any implementations
-	if sc, ok := interface{}(r.adapter).(ResourceComponenter); ok {
-		return sc.GetSupportedComponents()
-	}
-	return []string{lib.VCALENDAR, lib.VEVENT}
 }
 
 // TODO: memoize

--- a/data/resource.go
+++ b/data/resource.go
@@ -2,14 +2,13 @@ package data
 
 import (
 	"fmt"
+	"github.com/laurent22/ical-go/ical"
 	"io/ioutil"
 	"log"
 	"os"
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/laurent22/ical-go"
 
 	"github.com/samedi/caldav-go/files"
 	"github.com/samedi/caldav-go/lib"
@@ -41,6 +40,11 @@ type ResourceAdapter interface {
 	GetContent() string
 	GetContentSize() int64
 	GetModTime() time.Time
+}
+
+// ResourceComponenter returns all supported components as strings, such as vtodo vevent etc
+type ResourceComponenter interface {
+	GetSupportedComponents() []string
 }
 
 // ResourceRecurrence represents a recurrence for a resource.
@@ -280,6 +284,15 @@ func (r *Resource) GetOwnerPath() (string, bool) {
 	}
 
 	return "", false
+}
+
+// GetSupportedComponents returns the components supported by a store
+func (r *Resource) GetSupportedComponents() []string {
+	// We're checking if the storage adapter implements the interface to not break any implementations
+	if sc, ok := interface{}(r.adapter).(ResourceComponenter); ok {
+		return sc.GetSupportedComponents()
+	}
+	return []string{lib.VCALENDAR, lib.VEVENT}
 }
 
 // TODO: memoize

--- a/global/global.go
+++ b/global/global.go
@@ -4,6 +4,7 @@ package global
 
 import (
 	"github.com/samedi/caldav-go/data"
+	"github.com/samedi/caldav-go/lib"
 )
 
 // Storage represents the global storage used in the CRUD operations of resources. Default storage is the `data.FileStorage`.
@@ -11,3 +12,6 @@ var Storage data.Storage = new(data.FileStorage)
 
 // User defines the current caldav user, which is the user currently interacting with the calendar.
 var User *data.CalUser
+
+// SupportedComponents contains all components which are supported by the current storage implementation
+var SupportedComponents = []string{lib.VCALENDAR, lib.VEVENT}

--- a/handlers/multistatus.go
+++ b/handlers/multistatus.go
@@ -121,7 +121,7 @@ func (ms *multistatusResp) Propstats(resource *data.Resource, reqprops []xml.Nam
 			}
 		case ixml.SUPPORTED_CALENDAR_COMPONENT_SET_TG:
 			if resource.IsCollection() {
-				for _, component := range resource.GetSupportedComponents() {
+				for _, component := range global.SupportedComponents {
 					// TODO: use ixml somehow to build the below tag
 					compTag := fmt.Sprintf(`<C:comp name="%s"/>`, component)
 					pvalue.Contents = append(pvalue.Contents, compTag)

--- a/handlers/multistatus.go
+++ b/handlers/multistatus.go
@@ -121,7 +121,7 @@ func (ms *multistatusResp) Propstats(resource *data.Resource, reqprops []xml.Nam
 			}
 		case ixml.SUPPORTED_CALENDAR_COMPONENT_SET_TG:
 			if resource.IsCollection() {
-				for _, component := range supportedComponents {
+				for _, component := range resource.GetSupportedComponents() {
 					// TODO: use ixml somehow to build the below tag
 					compTag := fmt.Sprintf(`<C:comp name="%s"/>`, component)
 					pvalue.Contents = append(pvalue.Contents, compTag)

--- a/handlers/shared.go
+++ b/handlers/shared.go
@@ -2,13 +2,9 @@ package handlers
 
 import (
 	"bytes"
-	"github.com/samedi/caldav-go/lib"
 	"io/ioutil"
 	"net/http"
 )
-
-// Supported ICal components on this server.
-var supportedComponents = []string{lib.VCALENDAR, lib.VEVENT}
 
 // This function reads the request body and restore its content, so that
 // the request body can be read a second time.


### PR DESCRIPTION
I'm building a todo app with support for caldav using this library. Since my todo app only supports `VTODO`, I added an extra interface to deligate the supported component types to the storage adaper.

I decided against extending `ResourceAdapter` to not break any existing implementations.