### PR TITLE
Fixed report method returning the same etag for all items

### DIFF
--- a/handlers/report.go
+++ b/handlers/report.go
@@ -113,8 +113,8 @@ func (rh reportHandler) fetchResourcesByFilters(origin *data.Resource, filtersXM
 			return reps, err
 		}
 
-		for _, resource := range resources {
-			reps = append(reps, reportRes{resource.Path, &resource, true})
+		for in, resource := range resources {
+			reps = append(reps, reportRes{resource.Path, &resources[in], true})
 		}
 	} else {
 		// the origin resource is not a collection, so returns just that as the result


### PR DESCRIPTION
When doing a `REPORT` request with a payload like this:
```xml
<calendar-query xmlns="urn:ietf:params:xml:ns:caldav" xmlns:D="DAV:">   
  <D:prop>
    <D:getetag/>
  </D:prop>
  <filter>
    <comp-filter name="VCALENDAR">
      <comp-filter name="VTODO"/>
    </comp-filter>
  </filter>
</calendar-query>
```
we expect to get a response with a list of (different) etags. Instead, the library returns a list with an entry for each item we want, but all items have exactly the same etag.
I looked through how this response is built up using the debugger, and my guess is that in `handlers/report.go:116`, the `resource` variable only contains a kind of pointer to the current element in the loop. When this is saved in `reps`, the pointer is always a pointer to the current element of the loop thus resulting in a slice where all elements being the same is returned. This pr fixes this.

Maybe this changed with the recent go update or I'm just using the library wrong. The fix should not break any existing behaviour.

My go version:
```
go version go1.12.4 linux/amd64
```